### PR TITLE
Implemented runner for k6 files. 

### DIFF
--- a/examples/k6-test-script.js
+++ b/examples/k6-test-script.js
@@ -1,7 +1,18 @@
 import http from 'k6/http';
 import { sleep } from 'k6';
 
+export let options = {
+  insecureSkipTLSVerify: true,
+  thresholds: {
+      'http_req_duration{kind:html}': ['avg<=250', 'p(95)<500'],
+  }
+};
+
 export default function () {
-  http.get('https://kubeshop.github.io/testkube/');
+  check(http.get('https://kubeshop.github.io/testkube/', {
+      tags: {'kind': 'html'},
+  }), {
+      "status is 200": (res) => res.status === 200,
+  });
   sleep(1);
 }

--- a/pkg/runner/k6-env-test-script.js
+++ b/pkg/runner/k6-env-test-script.js
@@ -1,0 +1,7 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export default function () {
+  http.get(`https://${__ENV.TARGET_HOSTNAME}/testkube/`);
+  sleep(1);
+}

--- a/pkg/runner/k6-test-script.js
+++ b/pkg/runner/k6-test-script.js
@@ -1,0 +1,7 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export default function () {
+  http.get('https://kubeshop.github.io/testkube/');
+  sleep(1);
+}


### PR DESCRIPTION
## Pull request description 

Implemented k6 runner with initial support for k6 test files. Executor arguments as well as env variables are passed on to k6.

Implements #2 
Relates to kubeshop/testkube#978

## Checklist (choose whats happened)

- [  ] breaking change! (describe)
- [x] tested locally
- [  ] tested on cluster
- [  ] added new dependencies
- [  ] updated the docs
- [x] added a test

