### PR TITLE
Implemented K6 runner with Git directory support (using Fetcher API)

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -2,7 +2,9 @@ name: Code build and checks
 
 on:
   push:
-    branches: [main]
+    # build all branches for now
+    # alternatively we could do '!main'
+    branches: ['**']
   pull_request:
     branches: [main]
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 NAME ?= testkube-k6-executor
 BIN_DIR ?= $(HOME)/bin
+NAMESPACE ?= "default"
 
 build:
 	go build -o $(BIN_DIR)/$(NAME) cmd/agent/main.go 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,16 @@ export default function () {
 Issue the following commands to create and start the script:
 ```bash
 kubectl testkube tests create --file examples/k6-test-script.js --type "k6/script" --name k6-test-script
-kubectl testkube tests run k6-test-script --watch k6-test-script
+kubectl testkube tests run --watch k6-test-script
 ```
 
 ## Examples
 
-TODO: add more examples
+```
+# run k6-test-script.js from this Git repository
+kubectl testkube tests create --git-uri https://github.com/kubeshop/testkube-executor-k6.git --git-branch main --git-path examples --type "k6/script" --name k6-test-script-git
+kubectl testkube tests run --args k6-test-script.js --watch k6-test-script-git
+```
 
 # Issues and enchancements 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ export default function () {
 Issue the following commands to create and start the script:
 ```bash
 kubectl testkube tests create --file examples/k6-test-script.js --type "k6/script" --name k6-test-script
-kubectl testkube tests create --name k6-test-script --watch
+kubectl testkube tests run k6-test-script --watch k6-test-script
 ```
 
 ## Examples

--- a/build/agent/Dockerfile
+++ b/build/agent/Dockerfile
@@ -7,11 +7,14 @@ ENV GOOS=linux
 
 RUN cd cmd/agent;go build -o /runner -mod mod -a .
 
-# build k6 with prometheus support
-RUN go install go.k6.io/xk6/cmd/xk6@latest && \
+# build k6 0.36.0 with prometheus support
+RUN go install go.k6.io/xk6/cmd/xk6@v0.6.1 && \
     xk6 build --with github.com/grafana/xk6-output-prometheus-remote
 
 FROM loadimpact/k6:0.36.0
+USER root
+RUN apk update && apk upgrade && apk add --no-cache git
+USER 12345
 WORKDIR /home/k6
 COPY --from=builder /runner /bin/runner
 COPY --from=builder /build/k6 /usr/bin/k6

--- a/examples/k6-executor.yaml
+++ b/examples/k6-executor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: testkube
 spec:
   executor_type: job
-  image: lreimer/testkube-k6-executor:0.36.0
+  # not best practice but for now we use latest
+  image: lreimer/testkube-k6-executor
   types:
   - k6/script

--- a/examples/k6-executor.yaml
+++ b/examples/k6-executor.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   executor_type: job
   # not best practice but for now we use latest
-  image: lreimer/testkube-k6-executor
+  image: kubeshop/testkube-k6-executor
   types:
   - k6/script

--- a/examples/k6-executor.yaml
+++ b/examples/k6-executor.yaml
@@ -7,5 +7,6 @@ spec:
   executor_type: job
   # not best practice but for now we use latest
   image: kubeshop/testkube-k6-executor:latest
+  # image: lreimer/testkube-k6-executor:latest
   types:
   - k6/script

--- a/examples/k6-executor.yaml
+++ b/examples/k6-executor.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   executor_type: job
   # not best practice but for now we use latest
-  image: kubeshop/testkube-k6-executor
+  image: kubeshop/testkube-k6-executor:latest
   types:
   - k6/script

--- a/examples/k6-test-script.js
+++ b/examples/k6-test-script.js
@@ -1,5 +1,5 @@
 import http from 'k6/http';
-import { sleep } from 'k6';
+import { sleep, check } from 'k6';
 
 export let options = {
   insecureSkipTLSVerify: true,

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -57,7 +57,12 @@ func (r *K6Runner) Run(execution testkube.Execution) (result testkube.ExecutionR
 		script_file := filepath.Join(directory, args[len(args)-1])
 		file_info, err := os.Stat(script_file)
 		if errors.Is(err, os.ErrNotExist) || file_info.IsDir() {
-			return result, fmt.Errorf("k6 script %s not found", script_file)
+			return testkube.ExecutionResult{
+				Status:       testkube.StatusPtr(testkube.ERROR__ExecutionStatus),
+				Output:       "",
+				OutputType:   "text/plain",
+				ErrorMessage: string(fmt.Sprintf("k6 script %s not found", script_file)),
+			}, nil
 		}
 	}
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1,7 +1,10 @@
 package runner
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/executor"
@@ -48,6 +51,14 @@ func (r *K6Runner) Run(execution testkube.Execution) (result testkube.ExecutionR
 	directory := ""
 	if execution.Content.IsDir() {
 		directory = path
+
+		// sanity checking
+		// the last argument needs to be an existing file
+		script_file := filepath.Join(directory, args[len(args)-1])
+		file_info, err := os.Stat(script_file)
+		if errors.Is(err, os.ErrNotExist) || file_info.IsDir() {
+			return result, fmt.Errorf("k6 script %s not found", script_file)
+		}
 	}
 
 	output.PrintEvent("Running k6", args)

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -139,9 +139,10 @@ func TestRunErrors(t *testing.T) {
 		execution.Args = []string{}
 
 		// when
-		_, err := runner.Run(*execution)
+		result, err := runner.Run(*execution)
 
 		// then
-		assert.Error(t, err)
+		assert.NoError(t, err)
+		assert.Equal(t, result.Status, testkube.ExecutionStatusError)
 	})
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -39,7 +39,7 @@ func TestRunFiles(t *testing.T) {
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent(string(k6_script))
-		execution.Args = []string{"--vus", "2", "--duration", "5s"}
+		execution.Args = []string{"--vus", "2", "--duration", "1s"}
 
 		// when
 		result, err := runner.Run(*execution)
@@ -60,6 +60,30 @@ func TestRunFiles(t *testing.T) {
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent(string(k6_script))
 		execution.Envs = map[string]string{"TARGET_HOSTNAME": "kubeshop.github.io"}
+
+		// when
+		result, err := runner.Run(*execution)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, result.Status, testkube.ExecutionStatusSuccess)
+	})
+}
+
+func TestRunDirs(t *testing.T) {
+	t.Run("Run k6 from directory with script argument", func(t *testing.T) {
+		// given
+		runner := NewRunner()
+		execution := testkube.NewQueuedExecution()
+		execution.Content = &testkube.TestContent{
+			Type_: string(testkube.TestContentTypeGitDir),
+			Repository: &testkube.Repository{
+				Uri:    "https://github.com/kubeshop/testkube-executor-k6.git",
+				Branch: "main",
+				Path:   "examples",
+			},
+		}
+		execution.Args = []string{"--duration", "1s", "k6-test-script.js"}
 
 		// when
 		result, err := runner.Run(*execution)

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -123,4 +123,25 @@ func TestRunErrors(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, result.Status, testkube.ExecutionStatusError)
 	})
+
+	t.Run("Run k6 from directory with missing script arg", func(t *testing.T) {
+		// given
+		runner := NewRunner()
+		execution := testkube.NewQueuedExecution()
+		execution.Content = &testkube.TestContent{
+			Type_: string(testkube.TestContentTypeGitDir),
+			Repository: &testkube.Repository{
+				Uri:    "https://github.com/kubeshop/testkube-executor-k6.git",
+				Branch: "main",
+				Path:   "examples",
+			},
+		}
+		execution.Args = []string{}
+
+		// when
+		_, err := runner.Run(*execution)
+
+		// then
+		assert.Error(t, err)
+	})
 }


### PR DESCRIPTION
## Pull request description 

Preliminary work on supporting Git directory based k6 tests. Currently uses the Fetcher API. Closes #4.

Will be refactored towards RUNNER_DATADIR support in the next increment addressed by #5 