### PR TITLE
Added k6 Cloud support to executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ kubectl testkube run test --watch k6-test-script
 kubectl testkube create test --git-uri https://github.com/kubeshop/testkube-executor-k6.git --git-branch main --git-path examples --type "k6/script" --name k6-test-script-git
 kubectl testkube run test --args examples/k6-test-script.js --watch k6-test-script-git
 
+# for local k6 execution use k6/run or k6/script (deprecated)
+kubectl testkube create test --file examples/k6-test-script.js --type "k6/run" --name k6-local-test
+
 # you can also run test scripts using k6 cloud
 # you need to pass the API token as test param
 kubectl testkube create test --file examples/k6-test-script.js --type "k6/cloud" --name k6-cloud-test

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ kubectl testkube run test --watch k6-test-script
 # run k6-test-script.js from this Git repository
 kubectl testkube create test --git-uri https://github.com/kubeshop/testkube-executor-k6.git --git-branch main --git-path examples --type "k6/script" --name k6-test-script-git
 kubectl testkube run test --args examples/k6-test-script.js --watch k6-test-script-git
+
+# you can also run test scripts using k6 cloud
+# you need to pass the API token as test param
+kubectl testkube create test --file examples/k6-test-script.js --type "k6/cloud" --name k6-cloud-test
+kubectl testkube run test --param K6_CLOUD_TOKEN=K6_CLOUD_TOKEN=<YOUR_K6_CLOUD_API_TOKEN> --watch k6-cloud-test
+
 ```
 
 # Issues and enchancements 

--- a/examples/k6-executor.yaml
+++ b/examples/k6-executor.yaml
@@ -10,3 +10,4 @@ spec:
   # image: lreimer/testkube-k6-executor:latest
   types:
   - k6/script
+  - k6/cloud

--- a/examples/k6-executor.yaml
+++ b/examples/k6-executor.yaml
@@ -10,4 +10,5 @@ spec:
   # image: lreimer/testkube-k6-executor:latest
   types:
   - k6/script
+  - k6/run
   - k6/cloud

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -45,7 +45,12 @@ func (r *K6Runner) Run(execution testkube.Execution) (result testkube.ExecutionR
 
 	args := []string{}
 
-	k6Subtype := strings.Split(execution.TestType, "/")[1]
+	k6TestType := strings.Split(execution.TestType, "/")
+	if len(k6TestType) != 2 {
+		return result.Err(fmt.Errorf("invalid test type %s", execution.TestType)), nil
+	}
+
+	k6Subtype := k6TestType[1]
 	if k6Subtype == K6_SCRIPT || k6Subtype == K6_RUN {
 		args = append(args, K6_RUN)
 	} else if k6Subtype == K6_CLOUD {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -89,10 +89,10 @@ func (r *K6Runner) Run(execution testkube.Execution) (result testkube.ExecutionR
 		directory = filepath.Join(r.Params.Datadir, "repo")
 
 		// sanity checking for test script
-		script_file := filepath.Join(directory, args[len(args)-1])
-		file_info, err := os.Stat(script_file)
-		if errors.Is(err, os.ErrNotExist) || file_info.IsDir() {
-			return result.Err(fmt.Errorf("k6 test script %s not found", script_file)), nil
+		scriptFile := filepath.Join(directory, args[len(args)-1])
+		fileInfo, err := os.Stat(scriptFile)
+		if errors.Is(err, os.ErrNotExist) || fileInfo.IsDir() {
+			return result.Err(fmt.Errorf("k6 test script %s not found", scriptFile)), nil
 		}
 	}
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -66,8 +66,8 @@ func (r *K6Runner) Run(execution testkube.Execution) (result testkube.ExecutionR
 			os.Setenv(key, value)
 		} else {
 			// pass to k6 using -e option
-			env_var := fmt.Sprintf("%s=%s", key, value)
-			args = append(args, "-e", env_var)
+			env := fmt.Sprintf("%s=%s", key, value)
+			args = append(args, "-e", env)
 		}
 	}
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -32,6 +32,10 @@ type K6Runner struct {
 	Params Params
 }
 
+const K6_CLOUD = "cloud"
+const K6_RUN = "run"
+const K6_SCRIPT = "script"
+
 func (r *K6Runner) Run(execution testkube.Execution) (result testkube.ExecutionResult, err error) {
 	// check that the datadir exists
 	_, err = os.Stat(r.Params.Datadir)
@@ -39,7 +43,16 @@ func (r *K6Runner) Run(execution testkube.Execution) (result testkube.ExecutionR
 		return result, err
 	}
 
-	args := []string{"run"}
+	args := []string{}
+
+	k6Subtype := strings.Split(execution.TestType, "/")[1]
+	if k6Subtype == K6_SCRIPT || k6Subtype == K6_RUN {
+		args = append(args, K6_RUN)
+	} else if k6Subtype == K6_CLOUD {
+		args = append(args, K6_CLOUD)
+	} else {
+		return result.Err(fmt.Errorf("unsupported test type %s", execution.TestType)), nil
+	}
 
 	// convert executor env variables to k6 env variables
 	for key, value := range execution.Envs {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -56,8 +56,14 @@ func (r *K6Runner) Run(execution testkube.Execution) (result testkube.ExecutionR
 
 	// convert executor env variables to k6 env variables
 	for key, value := range execution.Envs {
-		env_var := fmt.Sprintf("%s=%s", key, value)
-		args = append(args, "-e", env_var)
+		if key == "K6_CLOUD_TOKEN" {
+			// set as OS environment variable
+			os.Setenv(key, value)
+		} else {
+			// pass to k6 using -e option
+			env_var := fmt.Sprintf("%s=%s", key, value)
+			args = append(args, "-e", env_var)
+		}
 	}
 
 	// pass additional executor arguments/flags to k6

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -20,6 +20,7 @@ func TestRunFiles(t *testing.T) {
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent("")
+		execution.TestType = "k6/script"
 		writeTestContent(t, tempDir, "../../examples/k6-test-script.js")
 
 		// when
@@ -36,6 +37,7 @@ func TestRunFiles(t *testing.T) {
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent("")
+		execution.TestType = "k6/run"
 		execution.Args = []string{"--vus", "2", "--duration", "1s"}
 		writeTestContent(t, tempDir, "../../examples/k6-test-script.js")
 
@@ -53,6 +55,7 @@ func TestRunFiles(t *testing.T) {
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent("")
+		execution.TestType = "k6/script"
 		execution.Envs = map[string]string{"TARGET_HOSTNAME": "kubeshop.github.io"}
 		writeTestContent(t, tempDir, "../../examples/k6-test-environment.js")
 
@@ -76,6 +79,7 @@ func TestRunAdvanced(t *testing.T) {
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent("")
+		execution.TestType = "k6/run"
 		writeTestContent(t, tempDir, "../../examples/k6-test-scenarios.js")
 
 		// when
@@ -92,6 +96,7 @@ func TestRunAdvanced(t *testing.T) {
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent("")
+		execution.TestType = "k6/script"
 		writeTestContent(t, tempDir, "../../examples/k6-test-thresholds.js")
 
 		// when
@@ -134,6 +139,7 @@ func TestRunDirs(t *testing.T) {
 				Branch: "main",
 			},
 		}
+		execution.TestType = "k6/script"
 		execution.Args = []string{"--duration", "1s", "k6-test-script.js"}
 
 		// when
@@ -156,6 +162,7 @@ func TestRunErrors(t *testing.T) {
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent("")
+		execution.TestType = "k6/script"
 
 		// when
 		result, err := runner.Run(*execution)
@@ -166,6 +173,25 @@ func TestRunErrors(t *testing.T) {
 		assert.Contains(t, result.ErrorMessage, "255")
 	})
 
+	t.Run("Run k6 with invalid test type script", func(t *testing.T) {
+		// setup
+		os.Setenv("RUNNER_DATADIR", ".")
+
+		// given
+		runner := NewRunner()
+		execution := testkube.NewQueuedExecution()
+		execution.Content = testkube.NewStringTestContent("")
+		execution.TestType = "k6/unknown"
+
+		// when
+		result, err := runner.Run(*execution)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, testkube.ExecutionStatusFailed, result.Status)
+		assert.Contains(t, result.ErrorMessage, "unsupported test type k6/unknown")
+	})
+
 	t.Run("Run k6 with invalid arguments", func(t *testing.T) {
 		// setup
 		os.Setenv("RUNNER_DATADIR", ".")
@@ -173,6 +199,7 @@ func TestRunErrors(t *testing.T) {
 		runner := NewRunner()
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent("")
+		execution.TestType = "k6/script"
 		execution.Args = []string{"--vues", "2", "--duration", "5"}
 
 		// when
@@ -199,6 +226,7 @@ func TestRunErrors(t *testing.T) {
 				Path:   "examples",
 			},
 		}
+		execution.TestType = "k6/script"
 		execution.Args = []string{}
 
 		// when


### PR DESCRIPTION
## Pull request description 

Adds basic support for running k6 tests using the k6 cloud service. Simply introduced a new test subtype to distinguish between local and cloud execution.

## Checklist (choose whats happened)

- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [x] added a test

## Changes
- added new test type `k6/cloud` and `k6/run` to distinguish between local and cloud execution
- added environment variable support for K6_CLOUD_TOKEN to pass API token 
