### PR TITLE
fix: verify summary of checks

### DIFF
--- a/examples/k6-test-failing-script.js
+++ b/examples/k6-test-failing-script.js
@@ -1,0 +1,10 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export default function () {
+  const baseURI = `${__ENV.API_URI || 'http://google.pl'}`;
+
+  check(http.get(`${baseURI}/joke`), {
+    'joke should be about Chuck': r => r.body.includes("Chuck") // this should fail
+  });
+}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -32,6 +32,23 @@ func TestRunFiles(t *testing.T) {
 		assert.Len(t, result.Steps, 1)
 	})
 
+	t.Run("Run k6 with simple failing script", func(t *testing.T) {
+		// given
+		runner := NewRunner()
+		execution := testkube.NewQueuedExecution()
+		execution.Content = testkube.NewStringTestContent("")
+		execution.TestType = "k6/script"
+		writeTestContent(t, tempDir, "../../examples/k6-test-failing-script.js")
+
+		// when
+		result, err := runner.Run(*execution)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, testkube.ExecutionStatusFailed, result.Status)
+		assert.Len(t, result.Steps, 1)
+	})
+
 	t.Run("Run k6 with arguments and simple script", func(t *testing.T) {
 		// given
 		runner := NewRunner()
@@ -104,7 +121,7 @@ func TestRunAdvanced(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
-		assert.Equal(t, result.ErrorMessage, "some thresholds have failed")
+		assert.Equal(t, "some thresholds have failed", result.ErrorMessage)
 		assert.Equal(t, testkube.ExecutionStatusFailed, result.Status)
 		assert.Len(t, result.Steps, 1)
 	})
@@ -247,7 +264,7 @@ func TestExecutionResult(t *testing.T) {
 			assert.FailNow(t, "Unable to read k6 test summary")
 		}
 
-		result := finalExecutionResult(summary, nil)
+		result := finalExecutionResult(string(summary), nil)
 		assert.Equal(t, testkube.ExecutionStatusPassed, result.Status)
 		assert.Len(t, result.Steps, 1)
 	})
@@ -259,7 +276,7 @@ func TestExecutionResult(t *testing.T) {
 			assert.FailNow(t, "Unable to read k6 test summary")
 		}
 
-		result := finalExecutionResult(summary, nil)
+		result := finalExecutionResult(string(summary), nil)
 		assert.Equal(t, testkube.ExecutionStatusPassed, result.Status)
 		assert.Len(t, result.Steps, 2)
 	})


### PR DESCRIPTION
Closes https://github.com/kubeshop/testkube/issues/1590

## Pull request description 
In this PR, code was added to look at the summary of the checks after a test run, and fail the test in case they are 100% passing.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

- added verification for summaries

## Fixes

-