### PR TITLE
fix: check for error messages and request failures

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -140,8 +140,7 @@ func finalExecutionResult(output string, err error) (result testkube.ExecutionRe
 
 // isSuccessful checks the output of the k6 test to make sure nothing fails
 func isSuccessful(summary string) bool {
-	return areChecksSuccessful(summary) && areRequestsSuccessful(summary) &&
-		!containsErrors(summary)
+	return areChecksSuccessful(summary) && !containsErrors(summary)
 }
 
 // areChecksSuccessful verifies the summary at the end of the execution to see
@@ -150,23 +149,6 @@ func areChecksSuccessful(summary string) bool {
 	lines := splitSummaryBody(summary)
 	for _, line := range lines {
 		if !strings.Contains(line, "checks") {
-			continue
-		}
-		if strings.Contains(line, "100.00%") {
-			return true
-		}
-		return false
-	}
-
-	return true
-}
-
-// areRequestsSuccessful verifies the summary at the end of the execution to see
-// if any of the http requests or thresholds failed
-func areRequestsSuccessful(summary string) bool {
-	lines := splitSummaryBody(summary)
-	for _, line := range lines {
-		if !strings.Contains(line, "http_req_failed") {
 			continue
 		}
 		if strings.Contains(line, "100.00%") {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -101,10 +101,11 @@ func (r *K6Runner) Run(execution testkube.Execution) (result testkube.ExecutionR
 
 // finalExecutionResult processes the output of the test run
 func finalExecutionResult(output string, err error) (result testkube.ExecutionResult) {
+	succeeded := isSuccessful(output)
 	switch {
-	case err == nil && areChecksSuccessful(output):
+	case err == nil && succeeded:
 		result.Status = testkube.ExecutionStatusPassed
-	case err == nil && !areChecksSuccessful(output):
+	case err == nil && !succeeded:
 		result.Status = testkube.ExecutionStatusFailed
 		result.ErrorMessage = "some checks have failed"
 	case err != nil && strings.Contains(err.Error(), "exit status 99"):
@@ -137,10 +138,16 @@ func finalExecutionResult(output string, err error) (result testkube.ExecutionRe
 	return result
 }
 
-// areChecksSuccessful verifies the summary at the end of the execution to see if any of the checks failed
+// isSuccessful checks the output of the k6 test to make sure nothing fails
+func isSuccessful(summary string) bool {
+	return areChecksSuccessful(summary) && areRequestsSuccessful(summary) &&
+		!containsErrors(summary)
+}
+
+// areChecksSuccessful verifies the summary at the end of the execution to see
+// if any of the checks failed
 func areChecksSuccessful(summary string) bool {
 	lines := splitSummaryBody(summary)
-
 	for _, line := range lines {
 		if !strings.Contains(line, "checks") {
 			continue
@@ -152,6 +159,31 @@ func areChecksSuccessful(summary string) bool {
 	}
 
 	return true
+}
+
+// areRequestsSuccessful verifies the summary at the end of the execution to see
+// if any of the http requests or thresholds failed
+func areRequestsSuccessful(summary string) bool {
+	lines := splitSummaryBody(summary)
+	for _, line := range lines {
+		if !strings.Contains(line, "http_req_failed") {
+			continue
+		}
+		if strings.Contains(line, "100.00%") {
+			return true
+		}
+		return false
+	}
+
+	return true
+}
+
+// containsErrors checks for error level messages.
+// As discussed in this GitHub issue: https://github.com/grafana/k6/issues/1680,
+// k6 summary does not include tests failing because an error was encountered.
+// To make sure no errors happened, we check the output for error level messages
+func containsErrors(summary string) bool {
+	return strings.Contains(summary, "level=error")
 }
 
 func parseScenarioNames(summary string) []string {


### PR DESCRIPTION
## Pull request description 

Closes https://github.com/kubeshop/testkube/issues/1590

During a discussion we noticed that running `fail()` in k6 will not make the k6 test actually fail, however we still want to show that the test did not succeed. This PR adds a check for error-level messages.

Follow-up Issue to return JUnit formatted result already exists: https://github.com/kubeshop/testkube/issues/1649

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-